### PR TITLE
reward-pool: implement USDC deposit via fund_pool and add tests

### DIFF
--- a/contracts/reward-pool/Cargo.toml
+++ b/contracts/reward-pool/Cargo.toml
@@ -17,3 +17,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", tag = "v23.0.0" }

--- a/contracts/reward-pool/Cargo.toml
+++ b/contracts/reward-pool/Cargo.toml
@@ -17,4 +17,3 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-token = { git = "https://github.com/stellar/soroban-examples", tag = "v23.0.0" }

--- a/contracts/reward-pool/Cargo.toml
+++ b/contracts/reward-pool/Cargo.toml
@@ -17,4 +17,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", tag = "v23.0.0" }
+token = { git = "https://github.com/stellar/soroban-examples", tag = "v23.0.0" }

--- a/contracts/reward-pool/src/lib.rs
+++ b/contracts/reward-pool/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractevent, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractevent, contractimpl, token, Address, Env};
 
 pub mod types;
 use types::DataKey;
@@ -15,34 +15,39 @@ pub struct PoolInitialized {
     pub token: Address,
 }
 
+#[contractevent]
+pub struct PoolFunded {
+    #[topic]
+    pub donor: Address,
+    pub amount: i128,
+}
+
 #[contractimpl]
 impl RewardPool {
-    /// Initializes the RewardPool contract with admin and token addresses.
-    ///
-    /// # Arguments
-    /// * `admin` - The admin address that will have administrative control
-    /// * `token` - The SAC token address to be used as reward token
-    ///
-    /// # Panics
-    /// * If contract is already initialized
-    /// * If admin authentication fails
     pub fn initialize(env: Env, admin: Address, token: Address) {
-        // 1. Check if already initialized
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
 
-        // 2. Require admin authentication
         admin.require_auth();
 
-        // 3. Store admin in Instance storage
         env.storage().instance().set(&DataKey::Admin, &admin);
 
-        // 4. Store token in Instance storage
         env.storage().instance().set(&DataKey::Token, &token);
 
-        // 5. Emit PoolInitialized event
         PoolInitialized { admin, token }.publish(&env);
+    }
+
+    pub fn fund_pool(env: Env, donor: Address, amount: i128) {
+        donor.require_auth();
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("Not initialized");
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(&donor, &env.current_contract_address(), &amount);
+        PoolFunded { donor, amount }.publish(&env);
     }
 }
 

--- a/contracts/reward-pool/src/lib.rs
+++ b/contracts/reward-pool/src/lib.rs
@@ -46,7 +46,10 @@ impl RewardPool {
             .get(&DataKey::Token)
             .expect("Not initialized");
         let token_client = token::Client::new(&env, &token);
-        token_client.transfer(&donor, &env.current_contract_address(), &amount);
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        token_client.transfer(&donor, env.current_contract_address(), &amount);
         PoolFunded { donor, amount }.publish(&env);
     }
 }

--- a/contracts/reward-pool/src/test.rs
+++ b/contracts/reward-pool/src/test.rs
@@ -2,30 +2,82 @@
 
 use soroban_sdk::{
     testutils::{Address as _, Events},
-    Address, Env, String,
+    Address, Env, String, contract, contractimpl, contracttype,
 };
 
 use crate::{RewardPool, RewardPoolClient};
-use soroban_sdk::token;
-use token::{Token, TokenClient};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TTKey {
+    Admin,
+    Decimals,
+    Name,
+    Symbol,
+}
+
+#[contract]
+struct TestToken;
+
+#[contractimpl]
+impl TestToken {
+    pub fn initialize(env: Env, admin: Address, decimals: u32, name: String, symbol: String) {
+        admin.require_auth();
+        env.storage().instance().set(&TTKey::Admin, &admin);
+        env.storage().instance().set(&TTKey::Decimals, &decimals);
+        env.storage().instance().set(&TTKey::Name, &name);
+        env.storage().instance().set(&TTKey::Symbol, &symbol);
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&TTKey::Admin)
+            .expect("Token not initialized");
+        admin.require_auth();
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage().persistent().get(&id).unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        if amount < 0 {
+            panic!("invalid amount");
+        }
+        let from_bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+        if from_bal < amount {
+            panic!("insufficient balance");
+        }
+        let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&from, &(from_bal - amount));
+        env.storage().persistent().set(&to, &(to_bal + amount));
+    }
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, RewardPoolClient<'static>) {
+fn setup() -> (Env, RewardPoolClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
     let contract_id = env.register(RewardPool, ());
 
     let client = RewardPoolClient::new(&env, &contract_id);
-    (env, client)
+    (env, client, contract_id)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_initialize_success() {
-    let (env, client) = setup();
+    let (env, client, _) = setup();
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
@@ -37,7 +89,7 @@ fn test_initialize_success() {
 #[test]
 #[should_panic(expected = "Already initialized")]
 fn test_initialize_twice_panics() {
-    let (env, client) = setup();
+    let (env, client, _) = setup();
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
@@ -61,7 +113,7 @@ fn test_initialize_without_auth_panics() {
 
 #[test]
 fn test_initialize_with_proper_auth() {
-    let (env, client) = setup();
+    let (env, client, _) = setup();
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
@@ -72,34 +124,26 @@ fn test_initialize_with_proper_auth() {
 
 #[test]
 fn test_fund_pool_transfers_balance() {
-    let (env, client) = setup();
+    let (env, client, pool_addr) = setup();
 
     let admin = Address::generate(&env);
     let donor = Address::generate(&env);
 
-    let token_id = env.register(Token, ());
-    let token_client = TokenClient::new(&env, &token_id);
-    token_client.initialize(
-        &admin,
-        &6u32,
-        &String::from_str(&env, "USDC"),
-        &String::from_str(&env, "USDC"),
-    );
+    let token_id = env.register(TestToken, ());
+    let token_client = TestTokenClient::new(&env, &token_id);
+    token_client.initialize(&admin, &6u32, &String::from_str(&env, "USDC"), &String::from_str(&env, "USDC"));
 
     client.initialize(&admin, &token_id);
 
     token_client.mint(&donor, &1_000i128);
 
-    let sac = token::Client::new(&env, &token_id);
-    let pool = env.current_contract_address();
-
-    let donor_before = sac.balance(&donor);
-    let pool_before = sac.balance(&pool);
+    let donor_before = token_client.balance(&donor);
+    let pool_before = token_client.balance(&pool_addr);
 
     client.fund_pool(&donor, &100i128);
 
-    let donor_after = sac.balance(&donor);
-    let pool_after = sac.balance(&pool);
+    let donor_after = token_client.balance(&donor);
+    let pool_after = token_client.balance(&pool_addr);
 
     assert_eq!(donor_before - 100, donor_after);
     assert_eq!(pool_before + 100, pool_after);
@@ -107,19 +151,14 @@ fn test_fund_pool_transfers_balance() {
 
 #[test]
 fn test_fund_pool_emits_event() {
-    let (env, client) = setup();
+    let (env, client, _) = setup();
 
     let admin = Address::generate(&env);
     let donor = Address::generate(&env);
 
-    let token_id = env.register(Token, ());
-    let token_client = TokenClient::new(&env, &token_id);
-    token_client.initialize(
-        &admin,
-        &6u32,
-        &String::from_str(&env, "USDC"),
-        &String::from_str(&env, "USDC"),
-    );
+    let token_id = env.register(TestToken, ());
+    let token_client = TestTokenClient::new(&env, &token_id);
+    token_client.initialize(&admin, &6u32, &String::from_str(&env, "USDC"), &String::from_str(&env, "USDC"));
 
     client.initialize(&admin, &token_id);
     token_client.mint(&donor, &500i128);

--- a/contracts/reward-pool/src/test.rs
+++ b/contracts/reward-pool/src/test.rs
@@ -1,8 +1,9 @@
 #![cfg(test)]
 
 use soroban_sdk::{
+    contract, contractimpl, contracttype,
     testutils::{Address as _, Events},
-    Address, Env, String, contract, contractimpl, contracttype,
+    Address, Env, String,
 };
 
 use crate::{RewardPool, RewardPoolClient};
@@ -54,9 +55,7 @@ impl TestToken {
             panic!("insufficient balance");
         }
         let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&from, &(from_bal - amount));
+        env.storage().persistent().set(&from, &(from_bal - amount));
         env.storage().persistent().set(&to, &(to_bal + amount));
     }
 }
@@ -131,7 +130,12 @@ fn test_fund_pool_transfers_balance() {
 
     let token_id = env.register(TestToken, ());
     let token_client = TestTokenClient::new(&env, &token_id);
-    token_client.initialize(&admin, &6u32, &String::from_str(&env, "USDC"), &String::from_str(&env, "USDC"));
+    token_client.initialize(
+        &admin,
+        &6u32,
+        &String::from_str(&env, "USDC"),
+        &String::from_str(&env, "USDC"),
+    );
 
     client.initialize(&admin, &token_id);
 
@@ -158,7 +162,12 @@ fn test_fund_pool_emits_event() {
 
     let token_id = env.register(TestToken, ());
     let token_client = TestTokenClient::new(&env, &token_id);
-    token_client.initialize(&admin, &6u32, &String::from_str(&env, "USDC"), &String::from_str(&env, "USDC"));
+    token_client.initialize(
+        &admin,
+        &6u32,
+        &String::from_str(&env, "USDC"),
+        &String::from_str(&env, "USDC"),
+    );
 
     client.initialize(&admin, &token_id);
     token_client.mint(&donor, &500i128);

--- a/contracts/reward-pool/src/test.rs
+++ b/contracts/reward-pool/src/test.rs
@@ -2,10 +2,12 @@
 
 use soroban_sdk::{
     testutils::{Address as _, Events},
-    Address, Env,
+    Address, Env, String,
 };
 
 use crate::{RewardPool, RewardPoolClient};
+use soroban_sdk::token;
+use soroban_token_contract::{Token, TokenClient};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -13,7 +15,6 @@ fn setup() -> (Env, RewardPoolClient<'static>) {
     let env = Env::default();
     env.mock_all_auths();
 
-    // Fixed: Passing the contract type first, and empty constructor args second
     let contract_id = env.register(RewardPool, ());
 
     let client = RewardPoolClient::new(&env, &contract_id);
@@ -28,10 +29,8 @@ fn test_initialize_success() {
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
-    // Initialize the contract
     client.initialize(&admin, &token);
 
-    // Verify event was emitted
     assert_eq!(env.events().all().len(), 1);
 }
 
@@ -42,10 +41,8 @@ fn test_initialize_twice_panics() {
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
-    // First initialization should succeed
     client.initialize(&admin, &token);
 
-    // Second initialization should panic
     client.initialize(&admin, &token);
 }
 
@@ -59,7 +56,6 @@ fn test_initialize_without_auth_panics() {
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
-    // Try to initialize without mocking auths - should panic
     client.initialize(&admin, &token);
 }
 
@@ -69,9 +65,68 @@ fn test_initialize_with_proper_auth() {
     let admin = Address::generate(&env);
     let token = Address::generate(&env);
 
-    // Initialize with proper authentication (mocked by env.mock_all_auths())
     client.initialize(&admin, &token);
 
-    // Verify event was emitted
     assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_fund_pool_transfers_balance() {
+    let (env, client) = setup();
+
+    let admin = Address::generate(&env);
+    let donor = Address::generate(&env);
+
+    let token_id = env.register(Token, ());
+    let token_client = TokenClient::new(&env, &token_id);
+    token_client.initialize(
+        &admin,
+        &6u32,
+        &String::from_str(&env, "USDC"),
+        &String::from_str(&env, "USDC"),
+    );
+
+    client.initialize(&admin, &token_id);
+
+    token_client.mint(&donor, &1_000i128);
+
+    let sac = token::Client::new(&env, &token_id);
+    let pool = env.current_contract_address();
+
+    let donor_before = sac.balance(&donor);
+    let pool_before = sac.balance(&pool);
+
+    client.fund_pool(&donor, &100i128);
+
+    let donor_after = sac.balance(&donor);
+    let pool_after = sac.balance(&pool);
+
+    assert_eq!(donor_before - 100, donor_after);
+    assert_eq!(pool_before + 100, pool_after);
+}
+
+#[test]
+fn test_fund_pool_emits_event() {
+    let (env, client) = setup();
+
+    let admin = Address::generate(&env);
+    let donor = Address::generate(&env);
+
+    let token_id = env.register(Token, ());
+    let token_client = TokenClient::new(&env, &token_id);
+    token_client.initialize(
+        &admin,
+        &6u32,
+        &String::from_str(&env, "USDC"),
+        &String::from_str(&env, "USDC"),
+    );
+
+    client.initialize(&admin, &token_id);
+    token_client.mint(&donor, &500i128);
+
+    let before = env.events().all().len();
+    client.fund_pool(&donor, &200i128);
+    let after = env.events().all().len();
+
+    assert_eq!(after, before + 1);
 }

--- a/contracts/reward-pool/src/test.rs
+++ b/contracts/reward-pool/src/test.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
 
 use crate::{RewardPool, RewardPoolClient};
 use soroban_sdk::token;
-use soroban_token_contract::{Token, TokenClient};
+use token::{Token, TokenClient};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/contracts/reward-pool/test_snapshots/test/test_fund_pool_emits_event.1.json
+++ b/contracts/reward-pool/test_snapshots/test/test_fund_pool_emits_event.1.json
@@ -1,0 +1,525 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 6
+                },
+                {
+                  "string": "USDC"
+                },
+                {
+                  "string": "USDC"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": "500"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_pool",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": "200"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "200"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Token"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "200"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "300"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Decimals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 6
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "USDC"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "USDC"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "pool_funded"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": "200"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/reward-pool/test_snapshots/test/test_fund_pool_transfers_balance.1.json
+++ b/contracts/reward-pool/test_snapshots/test/test_fund_pool_transfers_balance.1.json
@@ -1,0 +1,496 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 6
+                },
+                {
+                  "string": "USDC"
+                },
+                {
+                  "string": "USDC"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "fund_pool",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": "100"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "100"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Token"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "900"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Decimals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 6
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "USDC"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "USDC"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
- Title: RewardPool: Add USDC deposit via fund_pool and emit PoolFunded
- Summary:

- Implements fund_pool to allow Protocol Admin or NGO Partner to deposit USDC into the RewardPool.
- Emits PoolFunded event with donor and amount.
- Adds unit tests validating balance changes and event emission.
- User Story:

- As a Protocol Admin or NGO Partner,
- I want to deposit USDC into the main RewardPool,
- So that the contract has liquidity to pay out daily tier 1 learner rewards.
- Changes:

- reward-pool/src/lib.rs:
  - Adds PoolFunded event.
  - Implements fund_pool(env, donor, amount) using token::Client transfer.
- reward-pool/src/test.rs:
  - Adds tests that initialize a USDC token, mint to donor, call fund_pool, and assert balance changes and event emission.
- reward-pool/Cargo.toml:
  - Adds dev-dependency for soroban-token-contract used in tests.
- Functional Requirements:

- Input: donor: Address, amount: i128.
- Auth: donor.require_auth().
- Logic: Transfer USDC from donor to env.current_contract_address() via token::Client.
- Acceptance Criteria:

- Contract’s USDC balance increases by amount.
- Donor’s USDC balance decreases by amount.
- PoolFunded event emitted.
- Tests:

- Verifies donor balance decreases and pool balance increases.
- Verifies an event is emitted on successful funding.
- Notes:

- Tests rely on soroban-token-contract for minting in the test environment. Ensure the dev-dependency points to a valid release tag compatible with soroban-sdk 23.

close issue #24