### PR TITLE
feat(stake-vault): add get_multiplier view function for cross-contrac…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stake-vault"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
   "contracts/course-registry",
   "contracts/reward-pool",
   "contracts/quest-engine",
-  "contracts/governance"
+  "contracts/governance",
+  "contracts/stake-vault"
 ]
 
 [workspace.dependencies]

--- a/contracts/stake-vault/Cargo.toml
+++ b/contracts/stake-vault/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stake-vault"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/stake-vault/src/lib.rs
+++ b/contracts/stake-vault/src/lib.rs
@@ -1,0 +1,32 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    UserStake(Address),
+}
+
+#[contracttype]
+pub struct StakeInfo {
+    pub amount: i128,
+    pub lock_timestamp: u64,
+}
+
+#[contract]
+pub struct StakeVault;
+
+#[contractimpl]
+impl StakeVault {
+    pub fn get_multiplier(env: Env, user: Address) -> u32 {
+        let stake_info = env.storage().persistent().get(&DataKey::UserStake(user)).unwrap_or(StakeInfo { amount: 0, lock_timestamp: 0 });
+        if stake_info.amount >= 500 {
+            200
+        } else if stake_info.amount >= 100 {
+            120
+        } else {
+            100
+        }
+    }
+}
+
+mod test;

--- a/contracts/stake-vault/src/test.rs
+++ b/contracts/stake-vault/src/test.rs
@@ -1,0 +1,50 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+#[test]
+fn test_get_multiplier() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StakeVault);
+    let client = StakeVaultClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    // Initial state (no stake)
+    assert_eq!(client.get_multiplier(&user), 100);
+
+    // Set stake to 50 (< 100)
+    let stake_info = StakeInfo { amount: 50, lock_timestamp: 0 };
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::UserStake(user.clone()), &stake_info);
+    });
+    assert_eq!(client.get_multiplier(&user), 100);
+
+    // Set stake to 100 (100 <= x < 500)
+    let stake_info = StakeInfo { amount: 100, lock_timestamp: 0 };
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::UserStake(user.clone()), &stake_info);
+    });
+    assert_eq!(client.get_multiplier(&user), 120);
+
+    // Set stake to 499 (100 <= x < 500)
+    let stake_info = StakeInfo { amount: 499, lock_timestamp: 0 };
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::UserStake(user.clone()), &stake_info);
+    });
+    assert_eq!(client.get_multiplier(&user), 120);
+
+    // Set stake to 500 (x >= 500)
+    let stake_info = StakeInfo { amount: 500, lock_timestamp: 0 };
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::UserStake(user.clone()), &stake_info);
+    });
+    assert_eq!(client.get_multiplier(&user), 200);
+
+    // Set stake to 1000 (x >= 500)
+    let stake_info = StakeInfo { amount: 1000, lock_timestamp: 0 };
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::UserStake(user.clone()), &stake_info);
+    });
+    assert_eq!(client.get_multiplier(&user), 200);
+}

--- a/contracts/stake-vault/test_snapshots/test/test_get_multiplier.1.json
+++ b/contracts/stake-vault/test_snapshots/test/test_get_multiplier.1.json
@@ -1,0 +1,149 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "UserStake"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "UserStake"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "1000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "lock_timestamp"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Added the `get_multiplier` view function to the `StakeVault` contract. This cross-contract view function returns a multiplier based on the amount of USDC staked by a user, and is used by the `RewardPool` and `QuestEngine` to calculate boosted payout amounts.
## Changes
- Implemented `get_multiplier(env: Env, user: Address) -> u32` in `contracts/stake-vault/src/lib.rs`.
- Created basic unit tests in `contracts/stake-vault/src/test.rs` to verify the staking threshold logic.
- Added `contracts/stake-vault` to the workspace members in `Cargo.toml`.
## Acceptance Criteria Verified
- [x] Returns 200 for stakes >= 500 USDC.
- [x] Returns 120 for stakes between 100 and 499 USDC.
- [x] Returns 100 for users with no stake or < 100 USDC.
**Depends on:** [StakeVault] Stake USDC for multipliers
Closes #48 