### PR TITLE
feat(course-registry): mint soulbound badge on course completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "contracts/course-registry",
   "contracts/reward-pool",
   "contracts/quest-engine",
+  "contracts/badge-nft",
   "contracts/governance"
 ]
 

--- a/contracts/badge-nft/Cargo.toml
+++ b/contracts/badge-nft/Cargo.toml
@@ -16,3 +16,6 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/badge-nft/Cargo.toml
+++ b/contracts/badge-nft/Cargo.toml
@@ -18,4 +18,6 @@ soroban-sdk = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [features]
+default = ["contract"]
+contract = []
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/badge-nft/src/lib.rs
+++ b/contracts/badge-nft/src/lib.rs
@@ -1,11 +1,21 @@
 #![no_std]
-use soroban_sdk::{contract, contractevent, contractimpl, Address, Env, Vec};
+use soroban_sdk::{contractclient, contractevent, Address, Env, Vec};
 
 pub mod types;
-use types::{Badge, DataKey};
+use types::Badge;
 
-#[contract]
-pub struct BadgeNFT;
+// `#[contractclient]` generates `BadgeNFTClient` in every build (no wasm exports).
+// `#[contractimpl]` on the struct below generates the wasm exports, but only
+// when the `contract` feature is enabled — preventing duplicate symbols when
+// this crate is linked as a dependency of another contract.
+#[contractclient(name = "BadgeNFTClient")]
+pub trait BadgeNFTInterface {
+    fn initialize(env: Env, admin: Address);
+    fn mint_badge(env: Env, caller: Address, learner: Address, course_id: u32);
+    fn get_badges(env: Env, learner: Address) -> Vec<Badge>;
+    fn get_badge_count(env: Env, learner: Address) -> u32;
+    fn has_badge(env: Env, learner: Address, course_id: u32) -> bool;
+}
 
 #[contractevent]
 pub struct BadgeMinted {
@@ -16,133 +26,112 @@ pub struct BadgeMinted {
     pub minted_at: u64,
 }
 
-#[contractimpl]
-impl BadgeNFT {
-    /// Initializes the BadgeNFT contract with the authorized registry address.
-    /// Must be called once upon deployment.
-    ///
-    /// # Arguments
-    /// * `admin` - The CourseRegistry contract address authorized to mint badges
-    ///
-    /// # Panics
-    /// * If contract is already initialized
-    pub fn initialize(env: Env, admin: Address) {
-        // 1. Check if already initialized
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
-        }
+// The actual contract struct and implementation are only compiled when building
+// the badge-nft wasm itself (default feature). Dependents disable this feature
+// to avoid duplicate symbol errors at link time.
+#[cfg(feature = "contract")]
+mod contract_impl {
+    use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
 
-        // 2. Store admin (registry) in Instance storage
-        env.storage().instance().set(&DataKey::Admin, &admin);
-    }
+    use crate::types::{Badge, DataKey};
+    use crate::BadgeMinted;
 
-    /// Mints a Soulbound Token (badge) directly to the learner's address.
-    /// Only the official protocol registry can trigger this.
-    ///
-    /// # Arguments
-    /// * `caller` - The caller address (must be the authorized registry)
-    /// * `learner` - The learner address to receive the badge
-    /// * `course_id` - The course ID for which the badge is being minted
-    ///
-    /// # Panics
-    /// * If caller authentication fails
-    /// * If caller is not the authorized registry
-    /// * If learner already has a badge for this course_id (duplicate minting)
-    pub fn mint_badge(env: Env, caller: Address, learner: Address, course_id: u32) {
-        // 1. caller.require_auth()
-        caller.require_auth();
+    #[contract]
+    pub struct BadgeNFT;
 
-        // 2. Fetch 'Admin' (Registry) address from Instance storage. Assert caller == Admin.
-        let stored_admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Contract not initialized");
-        assert!(
-            caller == stored_admin,
-            "Unauthorized: Caller is not the authorized registry"
-        );
-
-        // 3. Construct DataKey::UserBadges(learner).
-        let badges_key = DataKey::UserBadges(learner.clone());
-
-        // 4. Fetch existing Vec<Badge> or initialize empty Vec.
-        let mut badges: Vec<Badge> = env
-            .storage()
-            .persistent()
-            .get(&badges_key)
-            .unwrap_or_else(|| Vec::new(&env));
-
-        // 5. Check if badge with course_id exists (prevent duplicates).
-        for existing_badge in badges.iter() {
-            if existing_badge.course_id == course_id {
-                panic!("Badge for this course already exists");
+    #[contractimpl]
+    impl BadgeNFT {
+        /// Initializes the BadgeNFT contract with the authorized registry address.
+        /// Must be called once upon deployment.
+        ///
+        /// # Panics
+        /// * If contract is already initialized
+        pub fn initialize(env: Env, admin: Address) {
+            if env.storage().instance().has(&DataKey::Admin) {
+                panic!("Already initialized");
             }
+            env.storage().instance().set(&DataKey::Admin, &admin);
         }
 
-        // 6. Push new Badge to Vec and save to Persistent storage.
-        let minted_at = env.ledger().timestamp();
-        let new_badge = Badge {
-            course_id,
-            minted_at,
-        };
+        /// Mints a Soulbound Token (badge) directly to the learner's address.
+        /// Only the official protocol registry can trigger this.
+        ///
+        /// # Panics
+        /// * If caller authentication fails
+        /// * If caller is not the authorized registry
+        /// * If learner already has a badge for this course_id (duplicate minting)
+        pub fn mint_badge(env: Env, caller: Address, learner: Address, course_id: u32) {
+            caller.require_auth();
 
-        badges.push_back(new_badge);
-        env.storage().persistent().set(&badges_key, &badges);
+            let stored_admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .expect("Contract not initialized");
+            assert!(
+                caller == stored_admin,
+                "Unauthorized: Caller is not the authorized registry"
+            );
 
-        // 7. Emit BadgeMinted event.
-        BadgeMinted {
-            learner,
-            course_id,
-            minted_at,
-        }
-        .publish(&env);
-    }
+            let badges_key = DataKey::UserBadges(learner.clone());
+            let mut badges: Vec<Badge> = env
+                .storage()
+                .persistent()
+                .get(&badges_key)
+                .unwrap_or_else(|| Vec::new(&env));
 
-    /// Returns all badges for a specific learner.
-    ///
-    /// # Arguments
-    /// * `learner` - The learner address
-    ///
-    /// # Returns
-    /// Vector of Badge structs. Returns empty vector if learner has no badges.
-    pub fn get_badges(env: Env, learner: Address) -> Vec<Badge> {
-        let badges_key = DataKey::UserBadges(learner);
-        env.storage()
-            .persistent()
-            .get(&badges_key)
-            .unwrap_or_else(|| Vec::new(&env))
-    }
-
-    /// Returns the count of badges for a specific learner.
-    ///
-    /// # Arguments
-    /// * `learner` - The learner address
-    ///
-    /// # Returns
-    /// Number of badges the learner owns.
-    pub fn get_badge_count(env: Env, learner: Address) -> u32 {
-        let badges = Self::get_badges(env, learner);
-        badges.len()
-    }
-
-    /// Checks if a learner has a specific badge.
-    ///
-    /// # Arguments
-    /// * `learner` - The learner address
-    /// * `course_id` - The course ID to check
-    ///
-    /// # Returns
-    /// true if the learner has the badge, false otherwise.
-    pub fn has_badge(env: Env, learner: Address, course_id: u32) -> bool {
-        let badges = Self::get_badges(env, learner);
-        for badge in badges.iter() {
-            if badge.course_id == course_id {
-                return true;
+            for existing_badge in badges.iter() {
+                if existing_badge.course_id == course_id {
+                    panic!("Badge for this course already exists");
+                }
             }
+
+            let minted_at = env.ledger().timestamp();
+            let new_badge = Badge {
+                course_id,
+                minted_at,
+            };
+            badges.push_back(new_badge);
+            env.storage().persistent().set(&badges_key, &badges);
+
+            BadgeMinted {
+                learner,
+                course_id,
+                minted_at,
+            }
+            .publish(&env);
         }
-        false
+
+        /// Returns all badges for a specific learner.
+        pub fn get_badges(env: Env, learner: Address) -> Vec<Badge> {
+            let badges_key = DataKey::UserBadges(learner);
+            env.storage()
+                .persistent()
+                .get(&badges_key)
+                .unwrap_or_else(|| Vec::new(&env))
+        }
+
+        /// Returns the count of badges for a specific learner.
+        pub fn get_badge_count(env: Env, learner: Address) -> u32 {
+            let badges = Self::get_badges(env, learner);
+            badges.len()
+        }
+
+        /// Checks if a learner has a specific badge.
+        pub fn has_badge(env: Env, learner: Address, course_id: u32) -> bool {
+            let badges = Self::get_badges(env, learner);
+            for badge in badges.iter() {
+                if badge.course_id == course_id {
+                    return true;
+                }
+            }
+            false
+        }
     }
 }
+
+// Re-export the struct so tests can use `badge_nft::BadgeNFT` for registration.
+#[cfg(feature = "contract")]
+pub use contract_impl::BadgeNFT;
 
 mod test;

--- a/contracts/course-registry/Cargo.toml
+++ b/contracts/course-registry/Cargo.toml
@@ -13,7 +13,9 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+badge-nft = { path = "../badge-nft", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+badge-nft = { path = "../badge-nft", features = ["testutils"] }
 

--- a/contracts/course-registry/src/lib.rs
+++ b/contracts/course-registry/src/lib.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{contract, contractevent, contractimpl, Address, BytesN, Env};
 pub mod types;
 use types::{Course, DataKey};
 
+use badge_nft::BadgeNFTClient;
+
 #[contract]
 pub struct CourseRegistry;
 
@@ -49,6 +51,26 @@ impl CourseRegistry {
             panic!("Already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Registers the BadgeNFT contract address so the registry can mint badges on completion.
+    /// Only callable by the Protocol Admin.
+    pub fn set_badge_nft_address(env: Env, admin: Address, badge_nft_address: Address) {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
+        assert!(
+            admin == stored_admin,
+            "Unauthorized: Caller is not the protocol admin"
+        );
+
+        env.storage()
+            .instance()
+            .set(&DataKey::BadgeNftAddress, &badge_nft_address);
     }
 
     /// Registers a new course on-chain.
@@ -281,11 +303,23 @@ impl CourseRegistry {
 
         // 8. Emit ModuleCompleted event
         ModuleCompleted {
-            learner,
+            learner: learner.clone(),
             course_id: id,
             new_progress,
         }
         .publish(&env);
+
+        // 9. If the learner just finished the final module, mint their soulbound badge
+        if new_progress == course.total_modules {
+            if let Some(badge_nft_address) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Address>(&DataKey::BadgeNftAddress)
+            {
+                let badge_nft = BadgeNFTClient::new(&env, &badge_nft_address);
+                badge_nft.mint_badge(&env.current_contract_address(), &learner, &id);
+            }
+        }
     }
 }
 

--- a/contracts/course-registry/src/test.rs
+++ b/contracts/course-registry/src/test.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
 };
 
 use crate::{CourseRegistry, CourseRegistryClient, DataKey};
+use badge_nft::{BadgeNFT, BadgeNFTClient};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -562,4 +563,130 @@ fn test_get_progress_tracks_completion() {
 
     client.complete_module(&admin, &learner, &course_id);
     assert_eq!(client.get_progress(&learner, &course_id), 3);
+}
+
+// ── Badge minting on course completion ───────────────────────────────────────
+
+/// Helper: deploys and initializes a BadgeNFT contract, authorizing the given registry address.
+fn setup_badge_nft<'a>(env: &Env, registry_address: &Address) -> BadgeNFTClient<'a> {
+    let badge_id = env.register(BadgeNFT, ());
+    let badge_client = BadgeNFTClient::new(env, &badge_id);
+    badge_client.initialize(registry_address);
+    badge_client
+}
+
+#[test]
+fn test_badge_minted_on_final_module_completion() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let instructor = Address::generate(&env);
+    let learner = Address::generate(&env);
+
+    client.initialize(&admin);
+    let course_id = client.create_course(&admin, &instructor, &2, &dummy_hash(&env));
+
+    // Deploy BadgeNFT and wire it up
+    let badge_client = setup_badge_nft(&env, &client.address);
+    client.set_badge_nft_address(&admin, &badge_client.address);
+
+    // Complete module 1 — no badge yet
+    client.complete_module(&admin, &learner, &course_id);
+    assert!(!badge_client.has_badge(&learner, &course_id));
+
+    // Complete module 2 (final) — badge must be minted
+    client.complete_module(&admin, &learner, &course_id);
+    assert!(badge_client.has_badge(&learner, &course_id));
+}
+
+#[test]
+fn test_badge_not_minted_on_intermediate_module() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let instructor = Address::generate(&env);
+    let learner = Address::generate(&env);
+
+    client.initialize(&admin);
+    let course_id = client.create_course(&admin, &instructor, &3, &dummy_hash(&env));
+
+    let badge_client = setup_badge_nft(&env, &client.address);
+    client.set_badge_nft_address(&admin, &badge_client.address);
+
+    // Complete only the first two of three modules
+    client.complete_module(&admin, &learner, &course_id);
+    client.complete_module(&admin, &learner, &course_id);
+
+    assert!(!badge_client.has_badge(&learner, &course_id));
+}
+
+#[test]
+fn test_badge_minted_for_multiple_learners_independently() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let instructor = Address::generate(&env);
+    let learner_a = Address::generate(&env);
+    let learner_b = Address::generate(&env);
+
+    client.initialize(&admin);
+    let course_id = client.create_course(&admin, &instructor, &1, &dummy_hash(&env));
+
+    let badge_client = setup_badge_nft(&env, &client.address);
+    client.set_badge_nft_address(&admin, &badge_client.address);
+
+    // Each learner completes the single-module course
+    client.complete_module(&admin, &learner_a, &course_id);
+    client.complete_module(&admin, &learner_b, &course_id);
+
+    assert!(badge_client.has_badge(&learner_a, &course_id));
+    assert!(badge_client.has_badge(&learner_b, &course_id));
+    assert_eq!(badge_client.get_badge_count(&learner_a), 1);
+    assert_eq!(badge_client.get_badge_count(&learner_b), 1);
+}
+
+#[test]
+fn test_badge_minted_for_different_courses_same_learner() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let instructor = Address::generate(&env);
+    let learner = Address::generate(&env);
+
+    client.initialize(&admin);
+    let course_a = client.create_course(&admin, &instructor, &1, &dummy_hash(&env));
+    let course_b = client.create_course(&admin, &instructor, &1, &dummy_hash(&env));
+
+    let badge_client = setup_badge_nft(&env, &client.address);
+    client.set_badge_nft_address(&admin, &badge_client.address);
+
+    client.complete_module(&admin, &learner, &course_a);
+    client.complete_module(&admin, &learner, &course_b);
+
+    assert!(badge_client.has_badge(&learner, &course_a));
+    assert!(badge_client.has_badge(&learner, &course_b));
+    assert_eq!(badge_client.get_badge_count(&learner), 2);
+}
+
+#[test]
+fn test_complete_module_without_badge_nft_configured_does_not_panic() {
+    // If set_badge_nft_address was never called, completion should still succeed
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let instructor = Address::generate(&env);
+    let learner = Address::generate(&env);
+
+    client.initialize(&admin);
+    let course_id = client.create_course(&admin, &instructor, &1, &dummy_hash(&env));
+
+    // No badge NFT address set — final module completion must not panic
+    client.complete_module(&admin, &learner, &course_id);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: Caller is not the protocol admin")]
+fn test_set_badge_nft_address_unauthorized_panics() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let fake_admin = Address::generate(&env);
+    let badge_address = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.set_badge_nft_address(&fake_admin, &badge_address);
 }

--- a/contracts/course-registry/src/types.rs
+++ b/contracts/course-registry/src/types.rs
@@ -16,4 +16,5 @@ pub enum DataKey {
     Progress(Address, u32),
     CourseCount,
     Admin,
+    BadgeNftAddress,
 }


### PR DESCRIPTION
- Add BadgeNFTClient cross-contract call inside complete_module
- Badge is minted only when new_progress == course.total_modules (final module)
- Add set_badge_nft_address admin function to wire up the BadgeNFT contract
- Add BadgeNftAddress variant to DataKey enum
- Add badge-nft as a dependency with testutils feature flag
- Add testutils feature to badge-nft crate
- Add 6 new tests covering badge minting, multi-learner, multi-course, graceful no-op when badge NFT not configured, and auth guard
- Regenerate stale complete_module test snapshots
- Close #54